### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/benign.py
+++ b/benign.py
@@ -4,7 +4,7 @@ import tarfile
 import time
 import json
 
-# def get_top_pypi_packages(url='https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json'):
+# def get_top_pypi_packages(url='https://hugovk.github.io/top-pypi-packages/top-pypi-packages.json'):
 #     response = requests.get(url)
 #     response.raise_for_status()
     

--- a/benignBuilder.ipynb
+++ b/benignBuilder.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_top_pypi_packages(url='https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json'):\n",
+    "def get_top_pypi_packages(url='https://hugovk.github.io/top-pypi-packages/top-pypi-packages.json'):\n",
     "    response = requests.get(url)\n",
     "    response.raise_for_status() \n",
     "    \n",


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.